### PR TITLE
🐛 Fix TextInput font-family to inherit from parent

### DIFF
--- a/packages/@mantine/core/src/components/Input/Input.module.css
+++ b/packages/@mantine/core/src/components/Input/Input.module.css
@@ -144,7 +144,7 @@
   color: var(--input-color);
   border: rem(1px) solid var(--input-bd);
   background-color: var(--input-bg);
-  font-family: var(--input-font-family, var(--mantine-font-family));
+  font-family: var(--input-font-family, inherit);
   height: var(--input-size);
   min-height: var(--input-height);
   line-height: var(--input-line-height);


### PR DESCRIPTION
## What does this PR do?

Changes the fallback font-family for Input components from `var(--mantine-font-family)` to `inherit`.

## Why was this change needed?

Previously, when no custom `--input-font-family` was set, Input components would always fall back to the global Mantine font family (`var(--mantine-font-family)`). This prevented inputs from inheriting the font-family from their parent elements, which is the expected behavior in most cases.

With this change, inputs will now properly inherit the font-family from their parent elements when no specific input font-family is defined, providing better integration with existing designs and typography systems.

## Changes

- `packages/@mantine/core/src/components/Input/Input.module.css`: Changed font-family fallback from `var(--mantine-font-family)` to `inherit`

## Test plan

- [ ] Verify that TextInput components inherit font-family from parent elements when no `--input-font-family` is set
- [ ] Confirm that custom `--input-font-family` values still work as expected
- [ ] Check that existing implementations are not broken

🤖 Generated with [Claude Code](https://claude.ai/code)